### PR TITLE
Parse metadata

### DIFF
--- a/rainbow/__init__.py
+++ b/rainbow/__init__.py
@@ -56,16 +56,16 @@ def read_metadata(path):
         path (str): Path of the directory.
 
     Returns:
-        DataDirectory representing the directory.
+        Dictionary representing the metadata of the directory.
 
     """
     datadir = None
     ext = os.path.splitext(path)[1]
     if ext.upper() == '.D':
-        datadir = agilent.read_metadata(path)
+        metadata = agilent.read_metadata(path)
     elif ext.lower() == '.raw':
-        datadir = waters.read_metadata(path)
+        metadata = waters.read_metadata(path)
 
-    if datadir is None:
+    if metadata is None:
         raise Exception(f"Rainbow cannot read {path}.")
-    return datadir
+    return metadata

--- a/rainbow/__init__.py
+++ b/rainbow/__init__.py
@@ -47,3 +47,25 @@ def read(path, prec=0, hrms=False):
     if datadir is None:
         raise Exception(f"Rainbow cannot read {path}.")
     return datadir
+
+def read_metadata(path):
+    """
+    Reads the metadata for a chromatogram data directory. Main method of the package.
+
+    Args:
+        path (str): Path of the directory.
+
+    Returns:
+        DataDirectory representing the directory.
+
+    """
+    datadir = None
+    ext = os.path.splitext(path)[1]
+    if ext.upper() == '.D':
+        datadir = agilent.read_metadata(path)
+    elif ext.lower() == '.raw':
+        datadir = waters.read_metadata(path)
+
+    if datadir is None:
+        raise Exception(f"Rainbow cannot read {path}.")
+    return datadir

--- a/rainbow/agilent/__init__.py
+++ b/rainbow/agilent/__init__.py
@@ -24,3 +24,18 @@ def read(path, prec=0, hrms=False):
     metadata = chemstation.parse_metadata(path, datafiles)
 
     return DataDirectory(path, datafiles, metadata)
+
+def read_metadata(path):
+    """
+    Reads metadata from an Agilent .D directory.
+
+    Args:
+        path (str): Path of the directory.
+
+    Returns:
+        DataDirectory representing the Agilent .D directory.
+
+    """
+    datafiles = []
+    metadata = chemstation.parse_metadata(path, datafiles)
+    return DataDirectory(path, datafiles, metadata)

--- a/rainbow/agilent/__init__.py
+++ b/rainbow/agilent/__init__.py
@@ -33,9 +33,12 @@ def read_metadata(path):
         path (str): Path of the directory.
 
     Returns:
-        DataDirectory representing the Agilent .D directory.
+        Dictionary representing metadata in the Agilent .D directory.
 
     """
     datafiles = []
     metadata = chemstation.parse_metadata(path, datafiles)
-    return DataDirectory(path, datafiles, metadata)
+    if len(metadata) == 1:
+        datadir = read(path)
+        return datadir.metadata if datadir else None
+    return metadata

--- a/rainbow/waters/__init__.py
+++ b/rainbow/waters/__init__.py
@@ -21,3 +21,18 @@ def read(path, prec=0):
     metadata = masslynx.parse_metadata(path)
 
     return DataDirectory(path, datafiles, metadata)
+
+def read_metadata(path):
+    """
+    Reads metdata from a Waters .raw directory.
+
+    Args:
+        path (str): Path of the directory.
+
+    Returns:
+        DataDirectory representing the Waters .raw directory.
+    """
+    datafiles = []
+    metadata = masslynx.parse_metadata(path)
+
+    return DataDirectory(path, datafiles, metadata)

--- a/rainbow/waters/__init__.py
+++ b/rainbow/waters/__init__.py
@@ -30,9 +30,11 @@ def read_metadata(path):
         path (str): Path of the directory.
 
     Returns:
-        DataDirectory representing the Waters .raw directory.
+        Dictionary representing metadata in the Waters .raw directory.
     """
     datafiles = []
     metadata = masslynx.parse_metadata(path)
-
-    return DataDirectory(path, datafiles, metadata)
+    if len(metadata) == 1:
+        datadir = read(path)
+        return datadir.metadata if datadir else None
+    return metadata

--- a/rainbow/waters/masslynx.py
+++ b/rainbow/waters/masslynx.py
@@ -65,7 +65,7 @@ def parse_spectrum(path, prec=0):
     # Each MS spectrum has an assigned polarity, 
     #     but may not have calibration values. 
     funcdat_paths = sorted([os.path.join(path, fn) for fn in os.listdir(path)
-                            if re.match('^_FUNC\d{3}.DAT$', fn)])
+                            if re.match(r'^_FUNC\d{3}.DAT$', fn)])
     funcdat_index = 0
     assert(os.path.getsize(os.path.join(path, "_FUNCTNS.INF")) == 32 * 13 * len(funcdat_paths))
     while funcdat_index < len(funcdat_paths):
@@ -182,7 +182,7 @@ def parse_funcdat2(path, pair_counts, prec=0, calib=None):
     # This code makes the assumption that in this format the  
     #     number of mz values is constant at each retention time. 
     inf_path = os.path.join(os.path.dirname(path), '_FUNCTNS.INF')
-    func_index = int(re.findall("\d+", os.path.basename(path))[0]) - 1
+    func_index = int(re.findall(r"\d+", os.path.basename(path))[0]) - 1
     mzs = parse_funcinf(inf_path)[func_index]
     ylabels = mzs[mzs != 0.0]
 
@@ -485,7 +485,7 @@ def parse_chroinf(path):
     f.seek(0x84) # start offset 
     analog_info = []
     while f.tell() < os.path.getsize(path):
-        line = re.sub('[\0-\x04]|\$CC\$|\([0-9]*\)', '', f.read(0x55)).strip()
+        line = re.sub(r'[\0-\x04]|\$CC\$|\([0-9]*\)', '', f.read(0x55)).strip()
         split = line.split(',')
         info = []
         info.append(split[0]) # name


### PR DESCRIPTION
Add a method to attempt to parse the metadata without reading all the data in the files. If this fails, the entire data is read and the metadata is returned.