### PR TITLE
Add GitHub Actions workflow to publish to PyPI on version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,65 @@
+name: Publish to PyPI
+
+# Publishes rainbow-api to PyPI whenever a version tag (e.g. v1.0.12) is pushed.
+# Uses PyPI Trusted Publishing (OIDC) — no API tokens are stored in the repo.
+#
+# Release flow:
+#   1. Bump `version` in pyproject.toml and merge to main.
+#   2. git tag -a v1.0.12 -m "Release 1.0.12" && git push origin v1.0.12
+#   3. This workflow builds the sdist + wheel and uploads them to PyPI.
+#
+# One-time setup on PyPI (Account -> Publishing -> Add a pending publisher):
+#   Owner:            evanyeyeye
+#   Repository name:  rainbow
+#   Workflow name:    publish.yml
+#   Environment name: pypi
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Check artifacts
+        run: |
+          python -m pip install --upgrade twine
+          python -m twine check dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write   # required for OIDC trusted publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,59 @@
+# Releasing rainbow-api to PyPI
+
+Releases are automated. **Pushing a version tag publishes to PyPI** — nothing
+else does. A normal commit or merge to `main` never triggers a release.
+
+## How to cut a release
+
+1. Edit `version` in `pyproject.toml` (e.g. `1.0.11` -> `1.0.12`) and merge it to `main`.
+2. Tag that commit and push the tag:
+
+   ```bash
+   git checkout main && git pull
+   git tag -a v1.0.12 -m "Release 1.0.12"
+   git push origin v1.0.12
+   ```
+
+That's it. Pushing the `v1.0.12` tag triggers
+`.github/workflows/publish.yml`, which builds the package and uploads it to
+PyPI. Watch it run under the repo's **Actions** tab; when it's green, verify
+with `pip install --upgrade rainbow-api`.
+
+Keep the tag version and the `pyproject.toml` version the same (both `1.0.12`).
+
+## Rules of thumb
+
+- `git push origin main` -> nothing publishes.
+- `git push origin v1.0.12` -> a release happens.
+- A version can only be published to PyPI **once**. If a release is broken,
+  bump to the next number (`1.0.13`) and tag again — you can't reuse `1.0.12`.
+
+## How the credentials work (the "sausage")
+
+The workflow publishes using PyPI **Trusted Publishing (OIDC)**: GitHub proves
+the workflow's identity to PyPI at run time, so there is **no API token** stored
+in the repo or on anyone's laptop.
+
+This relies on a one-time setting on PyPI (Account -> Publishing -> pending
+publisher) that must match the workflow:
+
+| Field            | Value          |
+| ---------------- | -------------- |
+| PyPI Project     | `rainbow-api`  |
+| Owner            | `evanyeyeye`   |
+| Repository       | `rainbow`      |
+| Workflow         | `publish.yml`  |
+| Environment      | `pypi`         |
+
+If a release tag builds successfully but fails at the publish step with an auth
+error, that trusted-publisher entry is missing or doesn't match.
+
+## Manual fallback (only if the workflow is broken)
+
+```bash
+pip install --upgrade build twine
+rm -rf dist build *.egg-info
+python -m build
+twine check dist/*
+twine upload dist/*        # needs a PyPI API token in ~/.pypirc
+```


### PR DESCRIPTION
## Summary
Automates PyPI releases so we don't have to build + `twine upload` by hand (see #39, which needed a manual 1.0.11 release).

Pushing a `v*` tag now triggers a workflow that builds the sdist + wheel, runs `twine check`, and uploads to PyPI via **Trusted Publishing (OIDC)** — no API token is stored in the repo or on anyone's laptop.

## Release flow after this merges
```
# bump version in pyproject.toml, merge to main, then:
git tag -a v1.0.12 -m "Release 1.0.12" && git push origin v1.0.12
```

## One-time PyPI setup required (won't publish until done)
On pypi.org -> Account -> Publishing -> Add a pending publisher:
- Owner: `evanyeyeye`
- Repository: `rainbow`
- Workflow: `publish.yml`
- Environment: `pypi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
